### PR TITLE
Added `@Accessor` macro

### DIFF
--- a/Sources/PropertyAccessor/PropertyAccessor.swift
+++ b/Sources/PropertyAccessor/PropertyAccessor.swift
@@ -10,6 +10,25 @@
 @freestanding(expression)
 public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "PropertyAccessorMacros", type: "StringifyMacro")
 
+/// A macro that adds the getter and the setter via the specified key path to the property.
+///
+/// For example,
+///
+///     @Accessor(to: \Self.foo.value)
+///     var fooValue: Int
+///
+/// produces
+///
+///     var fooValue: Int {
+///         get {
+///             self[keyPath: \Self.foo.value]
+///         }
+///         set {
+///             self[keyPath: \Self.foo.value] = newValue
+///         }
+///     }
+///
+/// You have to specify the key path where `Root` is `Self`.
 @attached(accessor)
 public macro Accessor<Root, Value>(
     to keyPath: KeyPath<Root, Value>

--- a/Sources/PropertyAccessor/PropertyAccessor.swift
+++ b/Sources/PropertyAccessor/PropertyAccessor.swift
@@ -9,3 +9,6 @@
 /// produces a tuple `(x + y, "x + y")`.
 @freestanding(expression)
 public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "PropertyAccessorMacros", type: "StringifyMacro")
+
+@attached(accessor)
+public macro Accessor() = #externalMacro(module: "PropertyAccessorMacros", type: "PropertyAccessorMacro")

--- a/Sources/PropertyAccessor/PropertyAccessor.swift
+++ b/Sources/PropertyAccessor/PropertyAccessor.swift
@@ -11,4 +11,6 @@
 public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "PropertyAccessorMacros", type: "StringifyMacro")
 
 @attached(accessor)
-public macro Accessor() = #externalMacro(module: "PropertyAccessorMacros", type: "PropertyAccessorMacro")
+public macro Accessor<Root, Value>(
+    to keyPath: KeyPath<Root, Value>
+) = #externalMacro(module: "PropertyAccessorMacros", type: "PropertyAccessorMacro")

--- a/Sources/PropertyAccessor/PropertyAccessor.swift
+++ b/Sources/PropertyAccessor/PropertyAccessor.swift
@@ -1,15 +1,3 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
-
-/// A macro that produces both a value and a string containing the
-/// source code that generated the value. For example,
-///
-///     #stringify(x + y)
-///
-/// produces a tuple `(x + y, "x + y")`.
-@freestanding(expression)
-public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "PropertyAccessorMacros", type: "StringifyMacro")
-
 /// A macro that adds the getter and the setter via the specified key path to the property.
 ///
 /// For example,

--- a/Sources/PropertyAccessorClient/main.swift
+++ b/Sources/PropertyAccessorClient/main.swift
@@ -11,6 +11,12 @@ struct Bar {
     @Accessor(to: \Self.foo.value)
     var fooValue: Int
     
+    @Accessor(to: \Self.foo.value)
+    var fooValue2: Int, fooValue3: Int
+    
+    @Accessor(to: \Self.foo.value)
+    let fooValueLet: Int
+    
     init(foo: Foo) {
         self.foo = foo
     }
@@ -18,5 +24,14 @@ struct Bar {
 
 var bar = Bar(foo: Foo(value: 10))
 print(bar.fooValue)
+
 bar.fooValue = 50
 print(bar.fooValue)
+
+bar.fooValue2 = 100
+print(bar.fooValue)
+
+bar.fooValue3 = 200
+print(bar.fooValue)
+
+print(bar.fooValueLet)

--- a/Sources/PropertyAccessorClient/main.swift
+++ b/Sources/PropertyAccessorClient/main.swift
@@ -1,8 +1,22 @@
 import PropertyAccessor
 
-let a = 17
-let b = 25
+struct Foo {
+    var value: Int
+}
 
-let (result, code) = #stringify(a + b)
+struct Bar {
+    
+    private var foo: Foo
+    
+    @Accessor(to: \Self.foo.value)
+    var fooValue: Int
+    
+    init(foo: Foo) {
+        self.foo = foo
+    }
+}
 
-print("The value \(result) was produced by the code \"\(code)\"")
+var bar = Bar(foo: Foo(value: 10))
+print(bar.fooValue)
+bar.fooValue = 50
+print(bar.fooValue)

--- a/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
+++ b/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
@@ -32,7 +32,21 @@ public struct PropertyAccessorMacro: AccessorMacro {
         providingAccessorsOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext
     ) throws -> [AccessorDeclSyntax] {
-        []
+        guard let argument = node.arguments?.as(LabeledExprListSyntax.self)?.first else {
+            fatalError("compiler bug: the macro does not have any arguments")
+        }
+        let keyPath = argument.expression
+        let getter = AccessorDeclSyntax(stringLiteral: """
+        get {
+            self[keyPath: \(keyPath)]
+        }
+        """)
+        let setter = AccessorDeclSyntax(stringLiteral: """
+        set {
+            self[keyPath: \(keyPath)] = newValue
+        }
+        """)
+        return [getter, setter]
     }
 }
 

--- a/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
+++ b/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
@@ -25,6 +25,22 @@ public struct StringifyMacro: ExpressionMacro {
     }
 }
 
+/// Implementation of the `Accessor` macro attached to the property,
+/// which adds the getter and the setter via the specified key path to the property.
+///
+///     @Accessor(to: \Self.foo.value)
+///     var fooValue: Int
+///
+/// will expand to
+///
+///     var fooValue: Int {
+///         get {
+///             self[keyPath: \Self.foo.value]
+///         }
+///         set {
+///             self[keyPath: \Self.foo.value] = newValue
+///         }
+///     }
 public struct PropertyAccessorMacro: AccessorMacro {
     
     public static func expansion(

--- a/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
+++ b/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
@@ -3,28 +3,6 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-/// Implementation of the `stringify` macro, which takes an expression
-/// of any type and produces a tuple containing the value of that expression
-/// and the source code that produced the value. For example
-///
-///     #stringify(x + y)
-///
-///  will expand to
-///
-///     (x + y, "x + y")
-public struct StringifyMacro: ExpressionMacro {
-    public static func expansion(
-        of node: some FreestandingMacroExpansionSyntax,
-        in context: some MacroExpansionContext
-    ) -> ExprSyntax {
-        guard let argument = node.argumentList.first?.expression else {
-            fatalError("compiler bug: the macro does not have any arguments")
-        }
-        
-        return "(\(argument), \(literal: argument.description))"
-    }
-}
-
 /// Implementation of the `Accessor` macro attached to the property,
 /// which adds the getter and the setter via the specified key path to the property.
 ///
@@ -69,7 +47,6 @@ public struct PropertyAccessorMacro: AccessorMacro {
 @main
 struct PropertyAccessorPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
-        StringifyMacro.self,
         PropertyAccessorMacro.self
     ]
 }

--- a/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
+++ b/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
@@ -30,17 +30,18 @@ public struct PropertyAccessorMacro: AccessorMacro {
             fatalError("compiler bug: the macro does not have any arguments")
         }
         let keyPath = argument.expression
-        let getter = AccessorDeclSyntax(stringLiteral: """
-        get {
-            self[keyPath: \(keyPath)]
-        }
-        """)
-        let setter = AccessorDeclSyntax(stringLiteral: """
-        set {
-            self[keyPath: \(keyPath)] = newValue
-        }
-        """)
-        return [getter, setter]
+        return [
+            """
+            get {
+                self[keyPath: \(keyPath)]
+            }
+            """,
+            """
+            set {
+                self[keyPath: \(keyPath)] = newValue
+            }
+            """
+        ]
     }
 }
 

--- a/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
+++ b/Sources/PropertyAccessorMacros/PropertyAccessorMacro.swift
@@ -25,9 +25,21 @@ public struct StringifyMacro: ExpressionMacro {
     }
 }
 
+public struct PropertyAccessorMacro: AccessorMacro {
+    
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingAccessorsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AccessorDeclSyntax] {
+        []
+    }
+}
+
 @main
 struct PropertyAccessorPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         StringifyMacro.self,
+        PropertyAccessorMacro.self
     ]
 }

--- a/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
+++ b/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
@@ -49,7 +49,7 @@ final class PropertyAccessorTests: XCTestCase {
         #if canImport(PropertyAccessorMacros)
         assertMacroExpansion(
             #"""
-            @Accessor
+            @Accessor(to: \Foo.value)
             private var value: Int
             """#,
             expandedSource: #"""

--- a/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
+++ b/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
@@ -7,43 +7,11 @@ import XCTest
 import PropertyAccessorMacros
 
 let testMacros: [String: Macro.Type] = [
-    "stringify": StringifyMacro.self,
     "Accessor": PropertyAccessorMacro.self
 ]
 #endif
 
 final class PropertyAccessorTests: XCTestCase {
-    func testMacro() throws {
-        #if canImport(PropertyAccessorMacros)
-        assertMacroExpansion(
-            """
-            #stringify(a + b)
-            """,
-            expandedSource: """
-            (a + b, "a + b")
-            """,
-            macros: testMacros
-        )
-        #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
-    }
-    
-    func testMacroWithStringLiteral() throws {
-        #if canImport(PropertyAccessorMacros)
-        assertMacroExpansion(
-            #"""
-            #stringify("Hello, \(name)")
-            """#,
-            expandedSource: #"""
-            ("Hello, \(name)", #""Hello, \(name)""#)
-            """#,
-            macros: testMacros
-        )
-        #else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-        #endif
-    }
     
     func testPropertyAccessorMacro() throws {
         #if canImport(PropertyAccessorMacros)

--- a/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
+++ b/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
@@ -8,6 +8,7 @@ import PropertyAccessorMacros
 
 let testMacros: [String: Macro.Type] = [
     "stringify": StringifyMacro.self,
+    "Accessor": PropertyAccessorMacro.self
 ]
 #endif
 
@@ -36,6 +37,23 @@ final class PropertyAccessorTests: XCTestCase {
             """#,
             expandedSource: #"""
             ("Hello, \(name)", #""Hello, \(name)""#)
+            """#,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+    
+    func testPropertyAccessorMacro() throws {
+        #if canImport(PropertyAccessorMacros)
+        assertMacroExpansion(
+            #"""
+            @Accessor
+            private var value: Int
+            """#,
+            expandedSource: #"""
+            private var value: Int
             """#,
             macros: testMacros
         )

--- a/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
+++ b/Tests/PropertyAccessorTests/PropertyAccessorTests.swift
@@ -49,11 +49,18 @@ final class PropertyAccessorTests: XCTestCase {
         #if canImport(PropertyAccessorMacros)
         assertMacroExpansion(
             #"""
-            @Accessor(to: \Foo.value)
-            private var value: Int
+            @Accessor(to: \Self.foo.value)
+            private var fooValue: Int
             """#,
             expandedSource: #"""
-            private var value: Int
+            private var fooValue: Int {
+                get {
+                    self [keyPath: \Self.foo.value]
+                }
+                set {
+                    self [keyPath: \Self.foo.value] = newValue
+                }
+            }
             """#,
             macros: testMacros
         )


### PR DESCRIPTION
# Features

- Added `@Accessor` macro.
  
  ```swift
  @Accessor(to: \Self.foo.value)
  var fooValue: Int
  ```
  
  expands to
  
  ```swift
  var fooValue: Int {
      get {
          self[keyPath: \Self.foo.value]
      }
      set {
          self[keyPath: \Self.foo.value] = newValue
      }
  }
  ```

# Maintenance

- Removed the macro template.